### PR TITLE
token helper tests

### DIFF
--- a/api/auth/endpoints/login.test.js
+++ b/api/auth/endpoints/login.test.js
@@ -5,7 +5,7 @@ const bcrypt = require("bcryptjs");
 
 beforeAll(() => {
   return db("users").truncate();
-}, 200);
+});
 
 describe("Auth Routes", () => {
   describe("Login Endpoint", () => {

--- a/api/auth/endpoints/register.test.js
+++ b/api/auth/endpoints/register.test.js
@@ -4,10 +4,17 @@ const db = require("../../../config/dbConfig.js");
 
 beforeAll(() => {
   return db("users").truncate();
-}, 200);
+});
 
 describe("Auth Routes", () => {
   describe("Register Endpoint", () => {
+    beforeAll(() => {
+      return new Promise((resolve, reject) => {
+        setTimeout(() => {
+          resolve();
+        }, 200);
+      });
+    });
     const username = "test1";
     const password1 = "pass1";
     const password2 = "pass2";

--- a/api/auth/endpoints/register.test.js
+++ b/api/auth/endpoints/register.test.js
@@ -9,6 +9,11 @@ beforeAll(() => {
 describe("Auth Routes", () => {
   describe("Register Endpoint", () => {
     beforeAll(() => {
+      // there seems to be some 1/20 issue of
+      // truncating in the main beforeAll
+      // to finish truncating after tests start running
+      // causing a failure 1/20 times
+      // so here i add a promise timeout to explicitly set a delay
       return new Promise((resolve, reject) => {
         setTimeout(() => {
           resolve();

--- a/api/auth/tokens/tokenHelpers.js
+++ b/api/auth/tokens/tokenHelpers.js
@@ -28,7 +28,9 @@ const verifyToken = async (req, res, next) => {
     try {
       decoded = jwt.verify(req.headers.authorization, jwtKey);
     } catch (error) {
-      res.status(400).json({ error });
+      res
+        .status(400)
+        .json({ error, message: "token invalid. login for new token" });
       return;
     }
 

--- a/api/auth/tokens/tokenHelpers.test.js
+++ b/api/auth/tokens/tokenHelpers.test.js
@@ -9,6 +9,11 @@ beforeAll(() => {
 describe("Token Vaidation", () => {
   describe("verifyToken middleware fn", () => {
     beforeAll(() => {
+      // there seems to be some 1/20 issue of
+      // truncating in the main beforeAll
+      // to finish truncating after tests start running
+      // causing a failure 1/20 times
+      // so here i add a promise timeout to explicitly set a delay
       return new Promise((resolve, reject) => {
         setTimeout(() => {
           resolve();

--- a/api/auth/tokens/tokenHelpers.test.js
+++ b/api/auth/tokens/tokenHelpers.test.js
@@ -1,0 +1,80 @@
+const { verifyToken, getToken } = require("./tokenHelpers.js");
+const { Req, Res, next } = require("../../testHelpers/testReqResNext.js");
+const db = require("../../../config/dbConfig.js");
+
+beforeAll(() => {
+  return db("users").truncate();
+});
+
+describe("Token Vaidation", () => {
+  describe("verifyToken middleware fn", () => {
+    beforeAll(() => {
+      return new Promise((resolve, reject) => {
+        setTimeout(() => {
+          resolve();
+        }, 200);
+      });
+    });
+    describe("responds 400 + message if:", () => {
+      test("no authorization header", async () => {
+        const res = new Res();
+        const req = new Req();
+        await verifyToken(req, res, next);
+        expect(res.statusCode).toBe(400);
+        expect(res.jsonSent.message).toContain("authorization");
+        expect(res.jsonSent.message).toContain("header");
+      });
+      test("token is invalid", async () => {
+        const res = new Res();
+        const req = new Req(
+          {},
+          {
+            authorization: "jsn010nsGARBAGETOKEN02884"
+          }
+        );
+        await verifyToken(req, res, next);
+        expect(res.statusCode).toBe(400);
+        expect(res.jsonSent.message).toContain("token");
+        expect(res.jsonSent.message).toContain("invalid");
+      });
+    });
+    describe("valid token should:", () => {
+      test("put user object from db on req body", async () => {
+        const username = "daBestUser";
+        const ids = await db("users").insert({
+          username,
+          password: "passPass",
+          email: "myEmail@email.emails"
+        });
+        const token = getToken(ids[0]);
+        const res = new Res();
+        const req = new Req(
+          {},
+          {
+            authorization: token
+          }
+        );
+        await verifyToken(req, res, next);
+        expect(req.user.username).toEqual(username);
+      });
+      test("not attach user password with user object", async () => {
+        const ids = await db("users").insert({
+          username: "daBestUser2",
+          password: "passPass2",
+          email: "myEmail2@email2.emails"
+        });
+        const token = getToken(ids[0]);
+        const res = new Res();
+        const req = new Req(
+          {},
+          {
+            authorization: token
+          }
+        );
+        await verifyToken(req, res, next);
+        expect(req.user.password).toBeUndefined();
+        expect(req.user).not.toBeUndefined();
+      });
+    });
+  });
+});

--- a/api/testHelpers/testReqResNext.js
+++ b/api/testHelpers/testReqResNext.js
@@ -1,7 +1,8 @@
 module.exports = {
   Req: class Req {
-    constructor(body) {
+    constructor(body = {}, headers = {}) {
       this.body = body;
+      this.headers = headers;
     }
   },
   Res: class Res {


### PR DESCRIPTION
also added promise timeouts in test files to force time between the db.truncate() that happens before each file is run.  I have been finding random errors with the database being cleared mid test-suite as a result of beforeAll or afterAll truncating.  now forcing a time out after the truncate is called may help avoid that error that seems to only happen 5-10% of the time.